### PR TITLE
Alternative inclusion of win32 code

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -193,8 +193,8 @@ static volatile sig_atomic_t handle_sig_alarm = 1;
 static volatile sig_atomic_t handle_sig_hup = 0;
 static int idle_limit = 0;
 
-__attribute_cold__
-int server_main (int argc, char ** argv);
+#define PRE_MAIN_HOOK
+#define POST_MAIN_HOOK
 
 #ifdef _WIN32
 #ifndef SIGBREAK
@@ -2260,12 +2260,11 @@ static int main_init_once (void) {
 #define server_status_running(srv) do { } while (0)
 #endif
 
-#ifndef main
-#define server_main main
-#endif
-
 __attribute_cold__
-int server_main (int argc, char ** argv) {
+int main (int argc, char ** argv) {
+
+    PRE_MAIN_HOOK
+
     if (!main_init_once()) return -1;
 
     int rc;
@@ -2326,6 +2325,8 @@ int server_main (int argc, char ** argv) {
         /* wait for all children to exit before graceful restart */
         while (fdevent_waitpid(-1, NULL, 0) > 0) ;
     } while (graceful_restart);
+
+    POST_MAIN_HOOK
 
     return rc;
 }


### PR DESCRIPTION
Hi @gstrauss :wave: This PR relates to what we started to discuss in https://github.com/birdofpreyru/react-native-static-server/issues/18 , in particular the way you hooked in win32 code using pre-processor redefinitions.

My problem with it is that for my library build use-case I use `main()` redefinition to add an extra `callback` argument, to be called prior to the main loop start, to signal the library consumer that server is ready to handle requests (and alternative solutions, like repeatedly pinging the target port until it starts responding, do not look better than a callback, from my perspective).

So, with the main branch version of Lighttpd it requires two pre-processor re-definitions: the `main()` signature itself, then the call to `server_main_loop()` inside `main()`, which is replaced by a call to my wrapper around `server_main_loop()`, which triggers the callback passed in, then calls the original `server_main_loop()`. These redefinitions were already, imho, cumbersome to understand if ones see the code for the first time, but kind of ok.

With your added `win32_main()` (which you now call differently in the latest version), I now have to make a few more re-definitions to add the extra `callback` argument to `win32_main()`, then to pass it down into the original `main()`, then to my `server_main_loop()` wrapper. Also, there is another place in win32 code where `win32_main()` is called, so if I add an extra argument to it, I also have to substitute that call. Thus, I end up with too many pre-processor definitions all around, which should be correctly placed with respect to each other, and even knowing what they do, it is hard to track it works as supposed.

This PR is my alternative suggestion. You don't really have to re-define main() for win32, you can just add `PRE_MAIN_HOOK` and `POST_MAIN_HOOK` literals to the original `main()`, and use pre-processor to substitute them with win32-specific pre-init and de-init code which you have now in your `win32_main()`. On other platforms they'll be just removed by pre-processor. This way the changes in `server.c` are even a few strings less than with your version, and no additional call stack levels added to the main loop. On my side, it is the very same `main()` function on all platforms, directly calling the same `server_main_loop()` at some point; thus with the original few pre-processor definitions I can add an extra `callback` argument to it, and pass it to my `server_main_loop()` wrapper.

What do you think about it? :) 