### PR TITLE
New ECH APIs

### DIFF
--- a/src/mod_openssl.c
+++ b/src/mod_openssl.c
@@ -546,6 +546,8 @@ static void ech_key_status_trace (server * const srv, SSL_CTX * const ssl_ctx)
 static int
 mod_openssl_refresh_ech_keys_ctx (server * const srv, plugin_ssl_ctx * const s, const time_t cur_ts)
 {
+    OSSL_ECHSTORE *es = NULL;
+
     if (NULL == s->ech_keydir
         || s->ech_keydir_refresh_ts + s->ech_keydir_refresh_interval > cur_ts)
         return 1;
@@ -554,26 +556,36 @@ mod_openssl_refresh_ech_keys_ctx (server * const srv, plugin_ssl_ctx * const s, 
     ech_key_status_trace(srv, s->ssl_ctx);
   #endif
 
-    if (s->ech_keydir_refresh_interval <= 0) {
+    es = SSL_CTX_get1_echstore(s->ssl_ctx);
+    if (es != NULL && s->ech_keydir_refresh_interval <= 0) {
         int nkeys = 0;
-        if (1 != SSL_CTX_ech_server_get_key_status(s->ssl_ctx, &nkeys)
-            || nkeys > 0)
+
+        if (1 == OSSL_ECHSTORE_num_keys(es, &nkeys)
+            && nkeys > 0) {
             /* Nothing to do if refresh time is disabled (zero or negative)
              * and keys already loaded */
+            OSSL_ECHSTORE_free(es);
             return 1;
+        }
+    }
+    if (es == NULL) {
+        es = OSSL_ECHSTORE_new(NULL, NULL);
+        if (es == NULL) 
+            log_error(srv->errh, __FILE__, __LINE__,
+              "SSL: OSSL_ECHSTORE_new failed");
     }
 
-    int rc = SSL_CTX_ech_server_flush_keys(s->ssl_ctx,
-                                           s->ech_keydir_refresh_interval+5);
+    int rc = OSSL_ECHSTORE_flush_keys(es, s->ech_keydir_refresh_interval+5);
     if (1 != rc)
         log_error(srv->errh, __FILE__, __LINE__,
-          "SSL: SSL_CTX_ech_server_flush_keys failed (%d)", rc);
+          "SSL: OSSL_ECHSTORE_flush_keys failed (%d)", rc);
 
     buffer * const b = s->ech_keydir;
     const uint32_t dirlen = buffer_string_length(b);
     DIR * const dp = opendir(b->ptr);
     if (NULL == dp) {
         log_perror(srv->errh,__FILE__,__LINE__,"%s dir:%s",__func__,b->ptr);
+        OSSL_ECHSTORE_free(es);
         return 0;
     }
 
@@ -589,23 +601,28 @@ mod_openssl_refresh_ech_keys_ctx (server * const srv, plugin_ssl_ctx * const s, 
 
         buffer_append_path_len(b, ep->d_name, nlen);    /* *.ech */
 
-        if (1 == SSL_CTX_ech_server_enable_file(s->ssl_ctx, b->ptr,
-                                                SSL_ECH_USE_FOR_RETRY)) {
+        BIO *in = BIO_new_file(b->ptr, "r");
+        if (in != NULL
+            && 1 == OSSL_ECHSTORE_read_pem(es, in, OSSL_ECH_FOR_RETRY)) {
           #ifdef LIGHTTPD_OPENSSL_ECH_DEBUG
             log_error(srv->errh, __FILE__, __LINE__,
-              "SSL: SSL_CTX_ech_server_enable_file() worked for %s", b->ptr);
+              "SSL: OSSL_ECHSTORE_read_pem () worked for %s", b->ptr);
           #endif
         }
         else {
             log_error(srv->errh, __FILE__, __LINE__,
-              "SSL: SSL_CTX_ech_server_enable_file() failed for %s", b->ptr);
+              "SSL: OSSL_ECHSTORE_read_pem () failed for %s", b->ptr);
             rc = 0;
         }
+        BIO_free_all(in);
 
         buffer_string_set_length(b, dirlen);
     }
 
     closedir(dp);
+
+    rc = SSL_CTX_set1_echstore(s->ssl_ctx, es);
+    OSSL_ECHSTORE_free(es);
 
   #ifdef LIGHTTPD_OPENSSL_ECH_DEBUG
     ech_key_status_trace(srv, s->ssl_ctx);
@@ -664,7 +681,7 @@ static void ech_status_trace(request_st *r, SSL *ssl)
 {
     char *sni_ech = NULL;
     char *sni_clr = NULL;
-    int status = SSL_ech_get_status(ssl, &sni_ech, &sni_clr);
+    int status = SSL_ech_get1_status(ssl, &sni_ech, &sni_clr);
     const char *str = ech_status_str(status);
     const char *ech = sni_ech ? sni_ech : "";
     const char *clr = sni_clr ? sni_clr : "";
@@ -765,7 +782,7 @@ mod_openssl_ech_only_policy_check (request_st * const r, handler_ctx * const hct
     char *sni_ech = NULL;
     char *sni_clr = NULL;
     handler_t rc = HANDLER_GO_ON;
-    switch (SSL_ech_get_status(hctx->ssl, &sni_ech, &sni_clr)) {
+    switch (SSL_ech_get1_status(hctx->ssl, &sni_ech, &sni_clr)) {
       case SSL_ECH_STATUS_SUCCESS:
         /* require that request :authority (Host) match SNI in ECH to avoid one
          * ECH-provided host testing for existence of another ECH-only host.
@@ -1658,7 +1675,7 @@ mod_openssl_SNI (handler_ctx *hctx, const char *servername, size_t len)
          * there is a need for such complex behavior on different ports.) */
         char *sni_ech = NULL;
         char *sni_clr = NULL;
-        int rc = SSL_ech_get_status(hctx->ssl, &sni_ech, &sni_clr);
+        int rc = SSL_ech_get1_status(hctx->ssl, &sni_ech, &sni_clr);
         OPENSSL_free(sni_ech);
         OPENSSL_free(sni_clr);
         switch (rc) {

--- a/src/mod_openssl.c
+++ b/src/mod_openssl.c
@@ -666,14 +666,16 @@ static void ech_status_trace(request_st *r, SSL *ssl)
     char *sni_clr = NULL;
     int status = SSL_ech_get_status(ssl, &sni_ech, &sni_clr);
     const char *str = ech_status_str(status);
-    if (sni_ech == NULL) sni_ech = "";
-    if (sni_clr == NULL) sni_clr = "";
+    const char *ech = sni_ech ? sni_ech : "";
+    const char *clr = sni_clr ? sni_clr : "";
     if (str)
         log_error(r->conf.errh, __FILE__, __LINE__,
-                  "ech_status: %s sni_clr: %s sni_ech: %s",str,sni_clr,sni_ech);
+                  "ech_status: %s sni_clr: %s sni_ech: %s", str, clr, ech);
     else
         log_error(r->conf.errh, __FILE__, __LINE__,
-                  "ech_status: %d sni_clr: %s sni_ech: %s",rc,sni_clr,sni_ech);
+                  "ech_status: %d sni_clr: %s sni_ech: %s", rc, clr, ech);
+    OPENSSL_free(sni_ech);
+    OPENSSL_free(sni_clr);
 }
 
 static unsigned int
@@ -762,6 +764,7 @@ mod_openssl_ech_only_policy_check (request_st * const r, handler_ctx * const hct
 
     char *sni_ech = NULL;
     char *sni_clr = NULL;
+    handler_t rc = HANDLER_GO_ON;
     switch (SSL_ech_get_status(hctx->ssl, &sni_ech, &sni_clr)) {
       case SSL_ECH_STATUS_SUCCESS:
         /* require that request :authority (Host) match SNI in ECH to avoid one
@@ -770,7 +773,7 @@ mod_openssl_ech_only_policy_check (request_st * const r, handler_ctx * const hct
         if (!mod_openssl_ech_only_host_match(CONST_BUF_LEN(r->http_host),
                                              sni_ech, strlen(sni_ech))) {
             r->http_status = 400;
-            return HANDLER_FINISHED;
+            rc = HANDLER_FINISHED;
         }
         break;
       /*case SSL_ECH_STATUS_NOT_TRIED:*/
@@ -786,17 +789,18 @@ mod_openssl_ech_only_policy_check (request_st * const r, handler_ctx * const hct
             const buffer *redo_host =
               mod_openssl_ech_only(hctx, CONST_BUF_LEN(&r->uri.authority));
             buffer * const http_host = r->http_host;
-            if (NULL == sni_clr)
-                *(const char **)&sni_clr =
-                  SSL_get_servername(hctx->ssl, TLSEXT_NAMETYPE_host_name);
-            if (NULL != sni_clr) {
+            const char *clr = sni_clr
+              ? sni_clr
+              : SSL_get_servername(hctx->ssl, TLSEXT_NAMETYPE_host_name);
+            if (NULL != clr) {
                 buffer * const tb = r->tmp_buf;
-                buffer_copy_string_len(tb, sni_clr, strlen(sni_clr));
+                buffer_copy_string_len(tb, clr, strlen(clr));
                 buffer_to_lower(tb); /*(normalized in policy checks)*/
                 if (0 != http_request_host_policy(tb,
                                                   r->conf.http_parseopts, 443)){
                     r->http_status = 400;
-                    return HANDLER_FINISHED;
+                    rc = HANDLER_FINISHED;
+                    break;
                 }
                 const buffer * const redo_host_sni =
                   mod_openssl_ech_only(hctx, CONST_BUF_LEN(tb));
@@ -820,11 +824,13 @@ mod_openssl_ech_only_policy_check (request_st * const r, handler_ctx * const hct
                 buffer_append_string_len(http_host, srv_token->ptr+o, n);
             }
             ++r->loops_per_request;
-            return HANDLER_COMEBACK;
+            rc = HANDLER_COMEBACK;
         }
         break;
     }
-    return HANDLER_GO_ON;
+    OPENSSL_free(sni_ech);
+    OPENSSL_free(sni_clr);
+    return rc;
 }
 
 #endif /* !OPENSSL_NO_ECH */
@@ -1652,7 +1658,10 @@ mod_openssl_SNI (handler_ctx *hctx, const char *servername, size_t len)
          * there is a need for such complex behavior on different ports.) */
         char *sni_ech = NULL;
         char *sni_clr = NULL;
-        switch (SSL_ech_get_status(hctx->ssl, &sni_ech, &sni_clr)) {
+        int rc = SSL_ech_get_status(hctx->ssl, &sni_ech, &sni_clr);
+        OPENSSL_free(sni_ech);
+        OPENSSL_free(sni_clr);
+        switch (rc) {
           case SSL_ECH_STATUS_SUCCESS:
             break;
           /*case SSL_ECH_STATUS_NOT_TRIED:*/
@@ -4319,14 +4328,13 @@ http_cgi_ssl_ech(request_st * const r, SSL * const ssl)
     int status = SSL_ech_get_status(ssl, &sni_ech, &sni_clr);
     const char *str = ech_status_str(status);
     if (str == NULL) str = "ECH status unknown"; /*(alt: format status to str)*/
-    if (NULL == sni_clr) *(const char **)&sni_clr = "NONE";
-    if (NULL == sni_ech) *(const char **)&sni_ech = "NONE";
-    http_header_env_set(r, CONST_STR_LEN("SSL_ECH_STATUS"),
-                        str, strlen(str));
-    http_header_env_set(r, CONST_STR_LEN("SSL_ECH_COVER"),
-                        sni_clr, strlen(sni_clr));
-    http_header_env_set(r, CONST_STR_LEN("SSL_ECH_HIDDEN"),
-                        sni_ech, strlen(sni_ech));
+    http_header_env_set(r, CONST_STR_LEN("SSL_ECH_STATUS"), str, strlen(str));
+    const char *clr = sni_clr ? sni_clr : "NONE";
+    http_header_env_set(r, CONST_STR_LEN("SSL_ECH_COVER"),  clr, strlen(clr));
+    const char *ech = sni_ech ? sni_ech : "NONE";
+    http_header_env_set(r, CONST_STR_LEN("SSL_ECH_HIDDEN"), ech, strlen(ech));
+    OPENSSL_free(sni_ech);
+    OPENSSL_free(sni_clr);
 }
 #endif
 

--- a/src/mod_openssl.c
+++ b/src/mod_openssl.c
@@ -86,6 +86,16 @@
 #endif
 #endif
 
+/* check defines from <openssl/ssl.h> for experimental ECH support */
+#if !defined(SSL_OP_ECH_GREASE)
+#define OPENSSL_NO_ECH
+#endif
+
+#ifndef OPENSSL_NO_ECH
+/*#define LIGHTTPD_OPENSSL_ECH_DEBUG*/ /*(ECH developer debug trace)*/
+#include <openssl/ech.h>
+#endif
+
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
 #include <openssl/core_names.h>
 #include <openssl/store.h>
@@ -117,6 +127,9 @@ typedef struct {
 
 typedef struct {
     SSL_CTX *ssl_ctx;
+    buffer *ech_keydir;
+    int32_t ech_keydir_refresh_interval;
+    time_t ech_keydir_refresh_ts;
 } plugin_ssl_ctx;
 
 typedef struct {
@@ -132,6 +145,7 @@ typedef struct {
     unsigned char ssl_honor_cipher_order; /* determine SSL cipher in server-preferred order, not client-order */
     const buffer *ssl_cipher_list;
     array *ssl_conf_cmd;
+    array *ech_opts;
 
     /*(copied from plugin_data for socket ssl_ctx config)*/
     const plugin_cert *pc;
@@ -503,6 +517,175 @@ ssl_tlsext_status_cb(SSL *ssl, void *arg)
 }
 #endif
 #endif
+
+
+#ifndef OPENSSL_NO_ECH
+
+#ifdef LIGHTTPD_OPENSSL_ECH_DEBUG
+static void ech_key_status_trace (server * const srv, SSL_CTX * const ssl_ctx)
+{
+    int numkeys = 0;
+    int ksrv = SSL_CTX_ech_server_get_key_status(ssl_ctx, &numkeys);
+    if (ksrv != 1)
+        log_error(srv->errh, __FILE__, __LINE__,
+          "SSL: SSL_CTX_ech_server_get_key_status failed (%d)", ksrv);
+    else
+        log_error(srv->errh, __FILE__, __LINE__,
+          "SSL: SSL_CTX_ech_server_get_key_status number of keys loaded %d",
+          numkeys);
+}
+#endif
+
+#include <dirent.h>
+static int
+mod_openssl_refresh_ech_keys_ctx (server * const srv, plugin_ssl_ctx * const s, const time_t cur_ts)
+{
+    if (NULL == s->ech_keydir
+        || s->ech_keydir_refresh_ts + s->ech_keydir_refresh_interval > cur_ts)
+        return 1;
+
+  #ifdef LIGHTTPD_OPENSSL_ECH_DEBUG
+    ech_key_status_trace(srv, s->ssl_ctx);
+  #endif
+
+    if (s->ech_keydir_refresh_interval <= 0) {
+        int nkeys = 0;
+        if (1 != SSL_CTX_ech_server_get_key_status(s->ssl_ctx, &nkeys)
+            || nkeys > 0)
+            /* Nothing to do if refresh time is disabled (zero or negative)
+             * and keys already loaded */
+            return 1;
+    }
+
+    int rc = SSL_CTX_ech_server_flush_keys(s->ssl_ctx,
+                                           s->ech_keydir_refresh_interval+5);
+    if (1 != rc)
+        log_error(srv->errh, __FILE__, __LINE__,
+          "SSL: SSL_CTX_ech_server_flush_keys failed (%d)", rc);
+
+    buffer * const b = s->ech_keydir;
+    const uint32_t dirlen = buffer_string_length(b);
+    DIR * const dp = opendir(b->ptr);
+    if (NULL == dp) {
+        log_perror(srv->errh,__FILE__,__LINE__,"%s dir:%s",__func__,b->ptr);
+        return 0;
+    }
+
+    /* load any echconfig files matching <name>.ech
+     *
+     * This code is derived from what was added to openssl s_server in
+     * apps/s_server.c stfcd openssl fork https://github.com/sftcd/openssl
+     */
+    for (struct dirent *ep; (ep = readdir(dp)); ) {
+        size_t nlen = strlen(ep->d_name);
+        if (nlen <= 4) continue;
+        if (0 != memcmp(ep->d_name+nlen-4, ".ech", 4)) continue;
+
+        buffer_append_path_len(b, ep->d_name, nlen);    /* *.ech */
+
+        if (1 == SSL_CTX_ech_server_enable_file(s->ssl_ctx, b->ptr,
+                                                SSL_ECH_USE_FOR_RETRY)) {
+          #ifdef LIGHTTPD_OPENSSL_ECH_DEBUG
+            log_error(srv->errh, __FILE__, __LINE__,
+              "SSL: SSL_CTX_ech_server_enable_file() worked for %s", b->ptr);
+          #endif
+        }
+        else {
+            log_error(srv->errh, __FILE__, __LINE__,
+              "SSL: SSL_CTX_ech_server_enable_file() failed for %s", b->ptr);
+            rc = 0;
+        }
+
+        buffer_string_set_length(b, dirlen);
+    }
+
+    closedir(dp);
+
+  #ifdef LIGHTTPD_OPENSSL_ECH_DEBUG
+    ech_key_status_trace(srv, s->ssl_ctx);
+  #endif
+
+    if (1 == rc) s->ech_keydir_refresh_ts = cur_ts;
+    return rc;
+}
+
+
+static void
+mod_openssl_refresh_ech_keys (server * const srv, const plugin_data *p, const time_t cur_ts)
+{
+    if (NULL != p->ssl_ctxs) {
+        SSL_CTX * const ssl_ctx_global_scope = p->ssl_ctxs->ssl_ctx;
+        /* refresh ech keys (if not copy of global scope) */
+        for (uint32_t i = 1; i < srv->config_context->used; ++i) {
+            plugin_ssl_ctx * const s = p->ssl_ctxs + i;
+            if (s->ssl_ctx && s->ssl_ctx != ssl_ctx_global_scope)
+                mod_openssl_refresh_ech_keys_ctx(srv, s, cur_ts);
+        }
+        /* refresh ech keys from global scope */
+        if (ssl_ctx_global_scope)
+            mod_openssl_refresh_ech_keys_ctx(srv, p->ssl_ctxs + 0, cur_ts);
+    }
+}
+
+
+#ifdef LIGHTTPD_OPENSSL_ECH_DEBUG
+
+__attribute_const__
+static const char * ech_status_str (int status)
+{
+  #define s(x) #x
+    switch (status) {
+      case SSL_ECH_STATUS_BACKEND:   return s(SSL_ECH_STATUS_BACKEND);
+      case SSL_ECH_STATUS_GREASE_ECH:return s(SSL_ECH_STATUS_GREASE_ECH);
+      case SSL_ECH_STATUS_GREASE:    return s(SSL_ECH_STATUS_GREASE);
+      case SSL_ECH_STATUS_SUCCESS:   return s(SSL_ECH_STATUS_SUCCESS);
+      case SSL_ECH_STATUS_FAILED:    return s(SSL_ECH_STATUS_FAILED);
+      case SSL_ECH_STATUS_BAD_CALL:  return s(SSL_ECH_STATUS_BAD_CALL);
+      case SSL_ECH_STATUS_NOT_TRIED: return s(SSL_ECH_STATUS_NOT_TRIED);
+      case SSL_ECH_STATUS_BAD_NAME:  return s(SSL_ECH_STATUS_BAD_NAME);
+      case SSL_ECH_STATUS_NOT_CONFIGURED:
+                                     return s(SSL_ECH_STATUS_NOT_CONFIGURED);
+      case SSL_ECH_STATUS_FAILED_ECH:return s(SSL_ECH_STATUS_FAILED_ECH);
+      case SSL_ECH_STATUS_FAILED_ECH_BAD_NAME:
+                                     return
+                                       s(SL_ECH_STATUS_FAILED_ECH_BAD_NAME);
+      default:                       return NULL;
+    }
+  #undef s
+}
+
+static void ech_status_trace(request_st *r, SSL *ssl)
+{
+    char *sni_ech = NULL;
+    char *sni_clr = NULL;
+    int status = SSL_ech_get_status(ssl, &sni_ech, &sni_clr);
+    const char *str = ech_status_str(status);
+    if (sni_ech == NULL) sni_ech = "";
+    if (sni_clr == NULL) sni_clr = "";
+    if (str)
+        log_error(r->conf.errh, __FILE__, __LINE__,
+                  "ech_status: %s sni_clr: %s sni_ech: %s",str,sni_clr,sni_ech);
+    else
+        log_error(r->conf.errh, __FILE__, __LINE__,
+                  "ech_status: %d sni_clr: %s sni_ech: %s",rc,sni_clr,sni_ech);
+}
+
+static unsigned int
+mod_openssl_ech_cb (SSL * const ssl, const char * const str)
+{
+    /*(callback is run after successful ECH extension decryption)*/
+    UNUSED(ssl);
+    UNUSED(str);
+  #ifdef LIGHTTPD_OPENSSL_ECH_DEBUG
+    handler_ctx * const hctx = (handler_ctx *) SSL_get_app_data(ssl);
+    ech_status_trace(hctx->r, ssl);
+  #endif
+    return 1;
+}
+
+#endif /* LIGHTTPD_OPENSSL_ECH_DEBUG */
+
+#endif /* !OPENSSL_NO_ECH */
 
 
 INIT_FUNC(mod_openssl_init)
@@ -1311,6 +1494,12 @@ mod_openssl_SNI (handler_ctx *hctx, const char *servername, size_t len)
         return SSL_TLSEXT_ERR_ALERT_FATAL;
   #endif
 
+  #ifndef OPENSSL_NO_ECH
+    /* (might be called again after ECH is decrypted) */
+    if (r->conditional_is_valid & (1 << COMP_HTTP_HOST))
+        config_cond_cache_reset_item(r, COMP_HTTP_HOST);
+  #endif
+
     r->conditional_is_valid |= (1 << COMP_HTTP_SCHEME)
                             |  (1 << COMP_HTTP_HOST);
     mod_openssl_patch_config(r, &hctx->conf);
@@ -1339,6 +1528,22 @@ mod_openssl_client_hello_cb (SSL *ssl, int *al, void *srv)
 
     const unsigned char *name;
     size_t len, slen;
+  #ifdef TLSEXT_TYPE_ech
+    /* code currently inactive; see top of file #undef SSL_CLIENT_HELLO_SUCCESS.
+     * Were the openssl ECH callback (set with SSL_CTX_ech_set_callback()) to
+     * become something other than what it currently is (mainly informational),
+     * then we might reconsider using it.  An alternative idea is to leverage
+     * the cert_cb (always called during client hello processing and set with
+     * SSL_CTX_set_cert_cb()) to access outcome of ECH or SNI immediately prior
+     * to server certificate selection.  Prior to existence of cert_cb, the use
+     * of servername_callback (set with SSL_CTX_set_tlsext_servername_callback)
+     * was needed to handle SNI, but might now be folded into cert_cb. */
+   #if 0
+    if (SSL_client_hello_get0_ext(ssl, TLSEXT_TYPE_ech, &name, &len)) {
+        return SSL_CLIENT_HELLO_SUCCESS; /* defer to later ECH processing */
+    }
+   #endif
+  #endif
     if (!SSL_client_hello_get0_ext(ssl, TLSEXT_TYPE_server_name, &name, &len)) {
         return SSL_CLIENT_HELLO_SUCCESS; /* client did not provide SNI */
     }
@@ -2635,6 +2840,22 @@ network_init_ssl (server *srv, plugin_config_socket *s, plugin_data *p)
             return -1;
       #endif
 
+      #ifndef OPENSSL_NO_ECH
+        if (s->ech_opts) {
+          #if defined(LIGHTTPD_OPENSSL_ECH_DEBUG)
+            SSL_CTX_ech_set_callback(s->ssl_ctx, mod_openssl_ech_cb);
+          #endif
+            /* enable SSL_OP_ECH_TRIALDECRYPT by default unless disabled;
+             * prefer "Options" => "ECHTrialDecrypt"
+             * in lighttpd ssl.openssl.ssl-conf-cmd */
+            if (config_plugin_value_tobool(
+                  array_get_element_klen(s->ech_opts,
+                                         CONST_STR_LEN("trial-decrypt")), 1)) {
+                SSL_CTX_set_options(s->ssl_ctx, SSL_OP_ECH_TRIALDECRYPT);
+            }
+        }
+      #endif
+
         if (s->ssl_conf_cmd && s->ssl_conf_cmd->used) {
             if (0 != network_openssl_ssl_conf_cmd(srv, s)) return -1;
             /* (force compression disabled, the default, if HTTP/2 enabled) */
@@ -2669,6 +2890,9 @@ mod_openssl_set_defaults_sockets(server *srv, plugin_data *p)
      ,{ CONST_STR_LEN("ssl.stek-file"),
         T_CONFIG_STRING,
         T_CONFIG_SCOPE_SERVER }
+     ,{ CONST_STR_LEN("ssl.ech-opts"),
+        T_CONFIG_ARRAY_KVANY,
+        T_CONFIG_SCOPE_SOCKET }
      ,{ NULL, 0,
         T_CONFIG_UNSET,
         T_CONFIG_SCOPE_UNSET }
@@ -2736,6 +2960,9 @@ mod_openssl_set_defaults_sockets(server *srv, plugin_data *p)
               case 4: /* ssl.stek-file */
                 if (!buffer_is_blank(cpv->v.b))
                     p->ssl_stek_file = cpv->v.b->ptr;
+                break;
+              case 5: /* ssl.ech-opts */
+                *(const array **)&conf.ech_opts = cpv->v.a;
                 break;
               default:/* should not happen */
                 break;
@@ -2842,6 +3069,17 @@ mod_openssl_set_defaults_sockets(server *srv, plugin_data *p)
         if (0 == network_init_ssl(srv, &conf, p)) {
             plugin_ssl_ctx * const s = p->ssl_ctxs + sidx;
             s->ssl_ctx = conf.ssl_ctx;
+            if (conf.ech_opts) {
+                array *ech_opts = conf.ech_opts;
+                const data_unset *du;
+                du = array_get_element_klen(ech_opts, CONST_STR_LEN("keydir"));
+                s->ech_keydir = du ? &((data_string *)du)->value : NULL;
+                if (s->ech_keydir && buffer_string_is_empty(s->ech_keydir))
+                    s->ech_keydir = NULL;
+                du = array_get_element_klen(ech_opts, CONST_STR_LEN("refresh"));
+                s->ech_keydir_refresh_interval =
+                  config_plugin_value_to_int32(du, 1800);
+            }
         }
         else {
             SSL_CTX_free(conf.ssl_ctx);
@@ -2852,6 +3090,11 @@ mod_openssl_set_defaults_sockets(server *srv, plugin_data *p)
   #ifdef TLSEXT_TYPE_session_ticket
     if (rc == HANDLER_GO_ON && ssl_is_init)
         mod_openssl_session_ticket_key_check(p, log_epoch_secs);
+  #endif
+
+  #ifdef TLSEXT_TYPE_ech
+    if (rc == HANDLER_GO_ON && ssl_is_init)
+        mod_openssl_refresh_ech_keys(srv, p, log_epoch_secs);
   #endif
 
     free(srvplug.cvlist);
@@ -3831,6 +4074,28 @@ https_add_ssl_client_entries (request_st * const r, handler_ctx * const hctx)
 }
 
 
+#ifdef LIGHTTPD_OPENSSL_ECH_DEBUG
+static void
+http_cgi_ssl_ech(request_st * const r, SSL * const ssl)
+{
+    /* add to environment ECH status, inner SNI, and outer SNI */
+    char *sni_ech = NULL;
+    char *sni_clr = NULL;
+    int status = SSL_ech_get_status(ssl, &sni_ech, &sni_clr);
+    const char *str = ech_status_str(status);
+    if (str == NULL) str = "ECH status unknown"; /*(alt: format status to str)*/
+    if (NULL == sni_clr) *(const char **)&sni_clr = "NONE";
+    if (NULL == sni_ech) *(const char **)&sni_ech = "NONE";
+    http_header_env_set(r, CONST_STR_LEN("SSL_ECH_STATUS"),
+                        str, strlen(str));
+    http_header_env_set(r, CONST_STR_LEN("SSL_ECH_COVER"),
+                        sni_clr, strlen(sni_clr));
+    http_header_env_set(r, CONST_STR_LEN("SSL_ECH_HIDDEN"),
+                        sni_ech, strlen(sni_ech));
+}
+#endif
+
+
 static void
 http_cgi_ssl_env (request_st * const r, handler_ctx * const hctx)
 {
@@ -3852,6 +4117,10 @@ http_cgi_ssl_env (request_st * const r, handler_ctx * const hctx)
         http_header_env_set(r, CONST_STR_LEN("SSL_CIPHER_ALGKEYSIZE"),
                             buf, li_itostrn(buf, sizeof(buf), algkeysize));
     }
+
+  #ifdef LIGHTTPD_OPENSSL_ECH_DEBUG
+    http_cgi_ssl_ech(r, hctx->ssl);
+  #endif
 }
 
 
@@ -3916,6 +4185,10 @@ TRIGGER_FUNC(mod_openssl_handle_trigger) {
 
   #ifndef OPENSSL_NO_OCSP
     mod_openssl_refresh_stapling_files(srv, p, cur_ts);
+  #endif
+
+  #ifdef TLSEXT_TYPE_ech
+    mod_openssl_refresh_ech_keys(srv, p, cur_ts);
   #endif
 
     return HANDLER_GO_ON;

--- a/src/mod_openssl.c
+++ b/src/mod_openssl.c
@@ -109,6 +109,7 @@
 #include "http_kv.h"
 #include "log.h"
 #include "plugin.h"
+#include "sock_addr.h"
 
 typedef struct {
     /* SNI per host: with COMP_SERVER_SOCKET, COMP_HTTP_SCHEME, COMP_HTTP_HOST */
@@ -130,6 +131,7 @@ typedef struct {
     buffer *ech_keydir;
     int32_t ech_keydir_refresh_interval;
     time_t ech_keydir_refresh_ts;
+    const array *ech_public_hosts;
 } plugin_ssl_ctx;
 
 typedef struct {
@@ -181,6 +183,7 @@ typedef struct {
     plugin_config defaults;
     server *srv;
     array *cafiles;
+    array *ech_only_hosts;
     const char *ssl_stek_file;
 } plugin_data;
 
@@ -200,10 +203,13 @@ typedef struct {
     connection *con;
     short renegotiations; /* count of SSL_CB_HANDSHAKE_START */
     short close_notify;
-    unsigned short alpn;
+    uint8_t alpn;
+    uint8_t ech_only_policy;
     plugin_config conf;
     buffer *tmp_buf;
     log_error_st *errh;
+    const array *ech_only_hosts;
+    const array *ech_public_hosts;
 } handler_ctx;
 
 
@@ -685,6 +691,142 @@ mod_openssl_ech_cb (SSL * const ssl, const char * const str)
 
 #endif /* LIGHTTPD_OPENSSL_ECH_DEBUG */
 
+
+__attribute_pure__
+static const buffer *
+mod_openssl_ech_only (const handler_ctx * const hctx, const char * const h, size_t hlen)
+{
+    /* design choice: match host SNI without port
+     *   (ech_only_hosts also have port stripped from config string at startup)
+     *   (might consider being more precise if sni_ech is canonicalized w/ port
+     *    if non-default port)
+     */
+    const char * const colon = memchr(h, ':', hlen);
+    if (colon) hlen = (size_t)(colon - h);
+
+    const array * const ech_only_hosts = hctx->ech_only_hosts;
+    const array * const ech_public_hosts = hctx->ech_public_hosts; /*("outer")*/
+    if (ech_only_hosts) {
+        const data_unset *du = array_get_element_klen(ech_only_hosts, h, hlen);
+        if (du) return &((const data_string *)du)->value;
+    }
+    if (ech_public_hosts
+        && NULL == array_get_element_klen(ech_public_hosts, h, hlen)) {
+        /*(return first host in ech_public_hosts list as non-ech-host)*/
+        return &ech_public_hosts->data[0]->key;
+    }
+    return NULL;
+}
+
+
+__attribute_pure__
+static int
+mod_openssl_ech_only_host_match (const char *a, size_t alen, const char *b, size_t blen)
+{
+    /* compare two host strings
+     * - host strings    with port must match exactly
+     * - host strings without port must match exactly
+     * - host string  without port must prefix-match host string with port
+     * This comparison tries to do this right thing with regards to what is
+     * generally expected when a port is not provided (for whatever reason),
+     * but does not reject the case where two ECH-only hosts with the same
+     * name, but different ports, are independent rather than the same site */
+
+    if (alen == blen)
+        return (0 == memcmp(a, b, alen)); /* chk exact match */
+
+    /* make a longer string, b shorter string, and len the prefix len */
+    size_t len = blen;
+    if (alen < blen) {
+        len = alen;
+        const char *t = b;
+        b = a;
+        a = t;
+    }
+
+    if (a[len] == ':' && 0 == memcmp(a, b, len)) {
+        for (a += len + 1; light_isdigit(*a); ++a) ;
+        return (*a == '\0');              /* chk prefix match, then port num */
+    }
+
+    return 0;
+}
+
+
+__attribute_cold__
+static handler_t
+mod_openssl_ech_only_policy_check (request_st * const r, handler_ctx * const hctx)
+{
+    if (NULL == r->http_host)
+        return HANDLER_GO_ON; /* ignore HTTP/1.0 without Host: header */
+
+    char *sni_ech = NULL;
+    char *sni_clr = NULL;
+    switch (SSL_ech_get_status(hctx->ssl, &sni_ech, &sni_clr)) {
+      case SSL_ECH_STATUS_SUCCESS:
+        /* require that request :authority (Host) match SNI in ECH to avoid one
+         * ECH-provided host testing for existence of another ECH-only host.
+         * 'sni_ech' is assumed normalized since ECH decryption succeeded. */
+        if (!mod_openssl_ech_only_host_match(CONST_BUF_LEN(r->http_host),
+                                             sni_ech, strlen(sni_ech))) {
+            r->http_status = 400;
+            return HANDLER_FINISHED;
+        }
+        break;
+      /*case SSL_ECH_STATUS_NOT_TRIED:*/
+      default:
+        if (0 == r->loops_per_request && r->http_host) {
+            /* avoid acknowledging existence of ECH-only host in request
+             * if connection not ECH and some hosts configured ECH-only */
+            /* always restart request once to minimize timing differences */
+            /* always attempt to do equivalent work, even if wasteful */
+            /* always attempt to provide same behavior for authority in
+             * request whether or not it matches cleartext SNI */
+            /* (r->uri.authority is ECH-only if redo_host *is not* NULL) */
+            const buffer *redo_host =
+              mod_openssl_ech_only(hctx, CONST_BUF_LEN(&r->uri.authority));
+            buffer * const http_host = r->http_host;
+            if (NULL == sni_clr)
+                *(const char **)&sni_clr =
+                  SSL_get_servername(hctx->ssl, TLSEXT_NAMETYPE_host_name);
+            if (NULL != sni_clr) {
+                buffer * const tb = r->tmp_buf;
+                buffer_copy_string_len(tb, sni_clr, strlen(sni_clr));
+                buffer_to_lower(tb); /*(normalized in policy checks)*/
+                if (0 != http_request_host_policy(tb,
+                                                  r->conf.http_parseopts, 443)){
+                    r->http_status = 400;
+                    return HANDLER_FINISHED;
+                }
+                const buffer * const redo_host_sni =
+                  mod_openssl_ech_only(hctx, CONST_BUF_LEN(tb));
+                redo_host = (NULL != redo_host)
+                  ? (NULL == redo_host_sni) ? tb : redo_host_sni
+                  : http_host;
+            }
+            else if (NULL == redo_host)
+                redo_host = http_host;
+            /* always copy r->http_host, even if copying over itself */
+            buffer_copy_buffer(http_host, redo_host);
+            /* always normalize port, if not 443 */
+            const server_socket * const srv_sock = r->con->srv_socket;
+            if (sock_addr_get_port(&srv_sock->addr) != 443) {
+                const char * const colon = strchr(http_host->ptr, ':');
+                if (colon)
+                    buffer_string_set_length(http_host, colon - http_host->ptr);
+                const buffer * const srv_token = srv_sock->srv_token;
+                const size_t o = srv_sock->srv_token_colon;
+                const size_t n = buffer_string_length(srv_token) - o;
+                buffer_append_string_len(http_host, srv_token->ptr+o, n);
+            }
+            ++r->loops_per_request;
+            return HANDLER_COMEBACK;
+        }
+        break;
+    }
+    return HANDLER_GO_ON;
+}
+
 #endif /* !OPENSSL_NO_ECH */
 
 
@@ -758,6 +900,7 @@ static void
 mod_openssl_free_config (server *srv, plugin_data * const p)
 {
     array_free(p->cafiles);
+    array_free(p->ech_only_hosts);
 
     if (NULL != p->ssl_ctxs) {
         SSL_CTX * const ssl_ctx_global_scope = p->ssl_ctxs->ssl_ctx;
@@ -1190,6 +1333,8 @@ mod_openssl_merge_config_cpv (plugin_config * const pconf, const config_plugin_v
       case 17:/* ssl.verifyclient.ca-crl-file */
         break;
      #endif
+      case 18:/* ssl.non-ech-host */
+        break;
       default:/* should not happen */
         return;
     }
@@ -1486,15 +1631,44 @@ mod_openssl_SNI (handler_ctx *hctx, const char *servername, size_t len)
 
     /* use SNI to patch mod_openssl config and then reset COMP_HTTP_HOST */
     buffer_copy_string_len_lc(&r->uri.authority, servername, len);
-  #if 0
-    /*(r->uri.authority used below for configuration before request read;
-     * revisit for h2)*/
+
+    /*(r->uri.authority used below for configuration before request read)
+     *(r->uri.authority is set here since it is used by config merging,
+     * but r->uri.authority is later overwritten by each HTTP request)*/
     if (0 != http_request_host_policy(&r->uri.authority,
                                       r->conf.http_parseopts, 443))
         return SSL_TLSEXT_ERR_ALERT_FATAL;
-  #endif
 
   #ifndef OPENSSL_NO_ECH
+    if (hctx->ech_only_policy) { /* ECH-only hosts are configured */
+        /*(given: r->uri.authority contains value from SSL_get_servername())*/
+        /*(check if host is ech-only before mod_openssl_patch_config() to try to
+         * avoid timing differences (which might reveal existence of specific
+         * ech-only host due to having to reset, re-patch if host is ech-only).
+         * This is possible with the global list of ech_only_hosts configured
+         * by ssl.non-ech-host.  We have chosen to unconditionally strip port
+         * to help admins avoid mistakes where ech-only host might be accessed
+         * on a different port.  Admin can use separate lighttpd instances if
+         * there is a need for such complex behavior on different ports.) */
+        char *sni_ech = NULL;
+        char *sni_clr = NULL;
+        switch (SSL_ech_get_status(hctx->ssl, &sni_ech, &sni_clr)) {
+          case SSL_ECH_STATUS_SUCCESS:
+            break;
+          /*case SSL_ECH_STATUS_NOT_TRIED:*/
+          default:
+            /* **ignore** cleartext SNI if servername is marked ECH-only;
+             * avoid acknowledging existence of host sent in cleartext SNI */
+            /* alternative: apply config for mod_openssl_ech_only() fallback */
+            if (NULL != mod_openssl_ech_only(hctx,
+                                             CONST_BUF_LEN(&r->uri.authority))){
+                buffer_clear(&r->uri.authority);
+                return SSL_TLSEXT_ERR_OK;
+            }
+            break;
+        }
+    }
+
     /* (might be called again after ECH is decrypted) */
     if (r->conditional_is_valid & (1 << COMP_HTTP_HOST))
         config_cond_cache_reset_item(r, COMP_HTTP_HOST);
@@ -3070,7 +3244,7 @@ mod_openssl_set_defaults_sockets(server *srv, plugin_data *p)
             plugin_ssl_ctx * const s = p->ssl_ctxs + sidx;
             s->ssl_ctx = conf.ssl_ctx;
             if (conf.ech_opts) {
-                array *ech_opts = conf.ech_opts;
+                const array * const ech_opts = conf.ech_opts;
                 const data_unset *du;
                 du = array_get_element_klen(ech_opts, CONST_STR_LEN("keydir"));
                 s->ech_keydir = du ? &((data_string *)du)->value : NULL;
@@ -3079,6 +3253,27 @@ mod_openssl_set_defaults_sockets(server *srv, plugin_data *p)
                 du = array_get_element_klen(ech_opts, CONST_STR_LEN("refresh"));
                 s->ech_keydir_refresh_interval =
                   config_plugin_value_to_int32(du, 1800);
+                du = array_get_element_klen(ech_opts,
+                                            CONST_STR_LEN("public-hosts"));
+                if (du && du->type == TYPE_ARRAY) {
+                    s->ech_public_hosts = &((data_array *)du)->value;
+                    if (s->ech_public_hosts->used == 0)
+                        s->ech_public_hosts = NULL;
+                    else {
+                        /*(error out if "public-hosts" has ports appended)
+                         *(could instead re-create/re-index array, but naw)*/
+                        const array * const a = s->ech_public_hosts;
+                        for (uint32_t j = 0; j < a->used; ++j) {
+                            const buffer * h = &a->data[j]->key;
+                            if (NULL != strchr(h->ptr, ':')) {
+                                log_error(srv->errh, __FILE__, __LINE__,
+                                  "ssl.ech-opts \"public-hosts\" must be listed"
+                                  "without port: %s", h->ptr);
+                                rc = HANDLER_ERROR;
+                            }
+                        }
+                    }
+                }
             }
         }
         else {
@@ -3181,6 +3376,9 @@ SETDEFAULTS_FUNC(mod_openssl_set_defaults)
         T_CONFIG_STRING,
         T_CONFIG_SCOPE_CONNECTION }
      ,{ CONST_STR_LEN("ssl.verifyclient.ca-crl-file"),
+        T_CONFIG_STRING,
+        T_CONFIG_SCOPE_CONNECTION }
+     ,{ CONST_STR_LEN("ssl.non-ech-host"),
         T_CONFIG_STRING,
         T_CONFIG_SCOPE_CONNECTION }
      ,{ NULL, 0,
@@ -3294,6 +3492,38 @@ SETDEFAULTS_FUNC(mod_openssl_set_defaults)
               case 16:/* ssl.verifyclient.ca-dn-file */
               case 17:/* ssl.verifyclient.ca-crl-file */
              #endif
+                break;
+              case 18:/* ssl.non-ech-host */
+                if (0 != i) {
+                    config_cond_info cfginfo;
+                    config_get_config_cond_info(&cfginfo,
+                                                (uint32_t)p->cvlist[i].k_id);
+                    if (cfginfo.comp == COMP_HTTP_HOST
+                        && cfginfo.cond == CONFIG_COND_EQ) {
+                        if (NULL == p->ech_only_hosts)
+                            p->ech_only_hosts = array_init(4);
+                      #if 0
+                        array_set_key_value(p->ech_only_hosts,
+                                            CONST_BUF_LEN(cfginfo.string),
+                                            CONST_BUF_LEN(cpv->v.b));
+                      #else
+                        /*(not expecting IPv6-literal as ECH-only)*/
+                        const char *kcolon = strchr(cfginfo.string->ptr, ':');
+                        size_t klen = kcolon
+                          ? (size_t)(kcolon - cfginfo.string->ptr)
+                          : buffer_string_length(cfginfo.string);
+                        array_set_key_value(p->ech_only_hosts,
+                                            cfginfo.string->ptr, klen,
+                                            CONST_BUF_LEN(cpv->v.b));
+                      #endif
+                    }
+                    else {
+                        log_error(srv->errh, __FILE__, __LINE__,
+                          "%s valid only in $HTTP[\"...\"] == \"...\" config "
+                          "condition, not: %s", cpk[cpv->k_id].k,
+                          cfginfo.comp_key);
+                    }
+                }
                 break;
               default:/* should not happen */
                 break;
@@ -3785,6 +4015,11 @@ CONNECTION_FUNC(mod_openssl_handle_con_accept)
 
     plugin_ssl_ctx *s = p->ssl_ctxs + srv_sock->sidx;
     if (NULL == s->ssl_ctx) s = p->ssl_ctxs; /*(inherit from global scope)*/
+  #ifndef OPENSSL_NO_ECH
+    hctx->ech_public_hosts = s->ech_public_hosts;
+    hctx->ech_only_hosts   = p->ech_only_hosts;
+    hctx->ech_only_policy  = (hctx->ech_only_hosts || hctx->ech_public_hosts);
+  #endif
     hctx->ssl = SSL_new(s->ssl_ctx);
     if (NULL != hctx->ssl
         && SSL_set_app_data(hctx->ssl, hctx)
@@ -4154,6 +4389,13 @@ REQUEST_FUNC(mod_openssl_handle_uri_raw)
     plugin_data *p = p_d;
     handler_ctx *hctx = r->con->plugin_ctx[p->id];
     if (NULL == hctx) return HANDLER_GO_ON;
+
+  #ifndef OPENSSL_NO_ECH
+    if (hctx->ech_only_policy) { /* ECH-only hosts are configured */
+        handler_t rc = mod_openssl_ech_only_policy_check(r, hctx);
+        if (HANDLER_GO_ON != rc) return rc;
+    }
+  #endif
 
     mod_openssl_patch_config(r, &hctx->conf);
     if (hctx->conf.ssl_verifyclient) {


### PR DESCRIPTION
This PR is a first attempt to show the changes needed in the ECH-experimental branch to use the new ECH APIs that have been agreed with the openssl maintainers, for the ECH feature branch.

The "official" [ECH feature branch](https://github.com/openssl/openssl/tree/feature/ech) doesn't yet include enough ECH code for this to work, two more planned PRs would need to be merged for that to work.

To get this working now, one needs to build against [an sftcd branch](https://github.com/sftcd/openssl/tree/feature/ech-both-sides-now) that has the ECH code for those two upcoming PRs already.

If all goes well, which may be a bit (but not hugely) optimistic, the "official" ECH feature branch will include those two PRs before the end of the year.

This PR has only had minimal testing with a server and client test script on localhost.